### PR TITLE
Feat/porcentajes y paginacion

### DIFF
--- a/backend/apps/transactions/tests/test_pagination.py
+++ b/backend/apps/transactions/tests/test_pagination.py
@@ -1,0 +1,59 @@
+from decimal import Decimal
+import pytest
+from rest_framework.test import APIClient
+from apps.users.models import CustomUser
+from apps.transactions.models import Transaction
+
+
+@pytest.fixture
+def user(db):
+    return CustomUser.objects.create_user(username='pag', password='x')
+
+
+def _make_transactions(user, n):
+    for i in range(n):
+        Transaction.objects.create(
+            user=user,
+            date=f'2026-05-{(i % 28) + 1:02d}T10:00:00Z',
+            amount=Decimal('1000'),
+            amount_clp=Decimal('1000'),
+            type='credito',
+            currency='CLP',
+            merchant=f'comercio-{i}',
+        )
+
+
+@pytest.mark.django_db
+def test_page_size_query_param_es_respetado(user):
+    _make_transactions(user, 30)
+    client = APIClient(); client.force_authenticate(user)
+
+    resp = client.get('/api/transactions/?page=1&page_size=25')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['count'] == 30          # total real, no la página
+    assert len(data['results']) == 25   # respeta el page_size pedido
+    assert data['next'] is not None     # hay una segunda página
+
+    resp2 = client.get('/api/transactions/?page=2&page_size=25')
+    assert len(resp2.json()['results']) == 5
+
+
+@pytest.mark.django_db
+def test_busqueda_abarca_todas_las_filas_no_solo_la_pagina(user):
+    # 30 transacciones genéricas + 1 que coincide con la búsqueda, fuera de la 1ª página.
+    _make_transactions(user, 30)
+    Transaction.objects.create(
+        user=user, date='2026-05-01T09:00:00Z', amount=Decimal('1000'),
+        amount_clp=Decimal('1000'), type='credito', currency='CLP',
+        merchant='UNICORNIO',
+    )
+    client = APIClient(); client.force_authenticate(user)
+
+    # Aunque pidamos una página pequeña, la búsqueda filtra sobre todo el dataset.
+    resp = client.get('/api/transactions/?page=1&page_size=10&search=UNICORNIO')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['count'] == 1
+    assert len(data['results']) == 1
+    assert data['results'][0]['merchant'] == 'UNICORNIO'

--- a/backend/finanzas/pagination.py
+++ b/backend/finanzas/pagination.py
@@ -1,0 +1,12 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class StandardResultsSetPagination(PageNumberPagination):
+    """PageNumberPagination que permite al cliente elegir el tamaño de página.
+
+    Mantiene el PAGE_SIZE por defecto (definido en settings) pero habilita el
+    parámetro ``page_size`` en la query string, acotado por ``max_page_size``.
+    """
+
+    page_size_query_param = 'page_size'
+    max_page_size = 200

--- a/backend/finanzas/settings/base.py
+++ b/backend/finanzas/settings/base.py
@@ -108,7 +108,7 @@ REST_FRAMEWORK = {
         'rest_framework.filters.SearchFilter',
         'rest_framework.filters.OrderingFilter',
     ],
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'finanzas.pagination.StandardResultsSetPagination',
     'PAGE_SIZE': 100,
 }
 

--- a/frontend/src/components/CategoryDoughnut.tsx
+++ b/frontend/src/components/CategoryDoughnut.tsx
@@ -1,6 +1,6 @@
 import { Doughnut } from 'react-chartjs-2'
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js'
-import { categoryColor } from '../utils/categoryColors'
+import { categoryColor, formatCLP } from '../utils/categoryColors'
 import { useChartTheme } from '../hooks/useChartTheme'
 
 ChartJS.register(ArcElement, Tooltip, Legend)
@@ -45,6 +45,15 @@ export default function CategoryDoughnut({ data, selectedCategories }: Props) {
             bodyColor: ct.tooltipText,
             borderColor: ct.tooltipBorder,
             borderWidth: 1,
+            callbacks: {
+              label: (ctx) => {
+                const value = ctx.parsed
+                const dataset = ctx.dataset.data as number[]
+                const sum = dataset.reduce((acc, v) => acc + (v || 0), 0)
+                const pct = sum > 0 ? (value / sum) * 100 : 0
+                return `${formatCLP(value)} (${pct.toFixed(1)}%)`
+              },
+            },
           },
         },
       }}

--- a/frontend/src/components/CategoryLegend.tsx
+++ b/frontend/src/components/CategoryLegend.tsx
@@ -11,21 +11,30 @@ interface Props {
 }
 
 export default function CategoryLegend({ data }: Props) {
+  const total = data.reduce((sum, cat) => sum + parseFloat(cat.net_total), 0)
+
   return (
     <ul className="space-y-2">
-      {data.map((cat, i) => (
-        <li key={cat.category_name} className="flex items-center gap-3">
-          <span className="text-xs text-surface-400 dark:text-surface-500 w-5 text-right">{i + 1}</span>
-          <span
-            className="w-3 h-3 rounded-full flex-shrink-0"
-            style={{ backgroundColor: categoryColor(cat.category_name) }}
-          />
-          <span className="text-sm text-surface-700 dark:text-surface-300 flex-1 truncate">{cat.category_name}</span>
-          <span className="text-sm font-medium text-surface-800 dark:text-surface-100 tabular-nums">
-            {formatCLP(parseFloat(cat.net_total))}
-          </span>
-        </li>
-      ))}
+      {data.map((cat, i) => {
+        const value = parseFloat(cat.net_total)
+        const pct = total > 0 ? (value / total) * 100 : 0
+        return (
+          <li key={cat.category_name} className="flex items-center gap-3">
+            <span className="text-xs text-surface-400 dark:text-surface-500 w-5 text-right">{i + 1}</span>
+            <span
+              className="w-3 h-3 rounded-full flex-shrink-0"
+              style={{ backgroundColor: categoryColor(cat.category_name) }}
+            />
+            <span className="text-sm text-surface-700 dark:text-surface-300 flex-1 truncate">{cat.category_name}</span>
+            <span className="text-sm font-medium text-surface-800 dark:text-surface-100 tabular-nums">
+              {formatCLP(value)}
+            </span>
+            <span className="text-xs text-surface-400 dark:text-surface-500 tabular-nums w-12 text-right">
+              {pct.toFixed(1)}%
+            </span>
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,74 @@
+interface Props {
+  page: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+/** Construye la lista de páginas a mostrar, con elipsis para rangos largos. */
+function pageRange(current: number, total: number): (number | '...')[] {
+  const delta = 1
+  const left = Math.max(2, current - delta)
+  const right = Math.min(total - 1, current + delta)
+  const range: (number | '...')[] = [1]
+
+  if (left > 2) range.push('...')
+  for (let i = left; i <= right; i++) range.push(i)
+  if (right < total - 1) range.push('...')
+  if (total > 1) range.push(total)
+
+  return range
+}
+
+const baseBtn =
+  'min-w-[2rem] px-2.5 py-1.5 text-sm rounded-input border transition-colors disabled:opacity-40 disabled:cursor-not-allowed'
+const inactiveBtn =
+  'border-surface-300 dark:border-surface-600 text-surface-700 dark:text-surface-300 ' +
+  'hover:bg-surface-50 dark:hover:bg-white/[0.06]'
+const activeBtn =
+  'border-primary-500 bg-primary-500 text-white dark:border-primary-400 dark:bg-primary-400'
+
+export default function Pagination({ page, totalPages, onPageChange }: Props) {
+  if (totalPages <= 1) return null
+
+  const pages = pageRange(page, totalPages)
+
+  return (
+    <nav className="flex items-center justify-center gap-1.5 mt-6 flex-wrap" aria-label="Paginación">
+      <button
+        type="button"
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        className={`${baseBtn} ${inactiveBtn}`}
+      >
+        Anterior
+      </button>
+
+      {pages.map((p, i) =>
+        p === '...' ? (
+          <span key={`gap-${i}`} className="px-1.5 text-surface-400 dark:text-surface-500 select-none">
+            …
+          </span>
+        ) : (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onPageChange(p)}
+            aria-current={p === page ? 'page' : undefined}
+            className={`${baseBtn} ${p === page ? activeBtn : inactiveBtn}`}
+          >
+            {p}
+          </button>
+        ),
+      )}
+
+      <button
+        type="button"
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        className={`${baseBtn} ${inactiveBtn}`}
+      >
+        Siguiente
+      </button>
+    </nav>
+  )
+}

--- a/frontend/src/hooks/useTransactions.ts
+++ b/frontend/src/hooks/useTransactions.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { fetchTransactions, updateTransaction } from '../api/transactions'
 import type { TransactionFilters } from '../types'
 
@@ -6,6 +6,9 @@ export function useTransactions(filters: TransactionFilters = {}) {
   return useQuery({
     queryKey: ['transactions', filters],
     queryFn: () => fetchTransactions(filters),
+    // Mantiene la página anterior visible mientras carga la siguiente,
+    // evitando que la tabla parpadee al paginar.
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -5,6 +5,9 @@ import FilterBar from '../components/FilterBar'
 import type { Filters } from '../components/FilterBar'
 import PageLayout from '../components/PageLayout'
 import EstimatesBanner from '../components/EstimatesBanner'
+import Pagination from '../components/Pagination'
+
+const PAGE_SIZE = 25
 
 export default function TransactionsPage() {
   const now = new Date()
@@ -12,24 +15,38 @@ export default function TransactionsPage() {
     year: now.getFullYear(),
     month: now.getMonth() + 1,
   })
+  const [page, setPage] = useState(1)
+
+  // Cualquier cambio de filtro o búsqueda reinicia a la primera página,
+  // así los resultados (que se buscan en todo el servidor) se ven desde el inicio.
+  function handleFiltersChange(next: Filters) {
+    setFilters(next)
+    setPage(1)
+  }
 
   const { data, isLoading } = useTransactions({
     ...filters,
     type: filters.type ? [filters.type] : undefined,
     ordering: '-date',
-    page_size: 100,
+    page,
+    page_size: PAGE_SIZE,
   })
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.count / PAGE_SIZE)) : 1
 
   return (
     <PageLayout maxWidth="wide">
       <h1 className="text-2xl font-bold text-surface-800 dark:text-surface-100 mb-4">Transacciones</h1>
       <div className="mb-6">
-        <FilterBar filters={filters} onChange={setFilters} />
+        <FilterBar filters={filters} onChange={handleFiltersChange} />
       </div>
       <EstimatesBanner show={!!data?.results.some((t) => t.fx_status === 'estimated')} />
       {isLoading && <p className="text-surface-500 dark:text-surface-400">Cargando...</p>}
       {data && data.results.length > 0 && (
-        <TransactionTable transactions={data.results} total={data.count} />
+        <>
+          <TransactionTable transactions={data.results} total={data.count} />
+          <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+        </>
       )}
       {data && data.results.length === 0 && (
         <div className="flex flex-col items-center justify-center py-20 text-center">


### PR DESCRIPTION
● feat: Porcentajes en gráficos + paginación y búsqueda global en transacciones
  
  Qué cambia

  1. Porcentajes en los gráficos del dashboard
  - La torta de distribución muestra el porcentaje de cada categoría en el tooltip (ej: $12.345 (23,4%)).
  - El ranking de gastos muestra el porcentaje siempre visible junto al monto, calculado sobre la suma de net_total.

  2. Paginación y búsqueda en Transacciones
  - Nuevos controles de paginación (Anterior/Siguiente + números con elipsis), con páginas de 25 filas.
  - La búsqueda opera sobre todo el dataset, no solo sobre las filas de la página actual (la búsqueda ya era server-side; ahora se navega el resto vía paginación y se reinicia a la página 1
  al filtrar/buscar).
  - Sin parpadeo al cambiar de página (keepPreviousData).

  Detalle técnico

  - Backend: nueva clase StandardResultsSetPagination que habilita page_size_query_param (máx. 200). Antes el page_size enviado por el frontend se ignoraba y siempre devolvía 100. Cambio
  aditivo: el default sigue siendo 100, no afecta a otros endpoints.
  - Frontend: nuevo componente Pagination; TransactionsPage gestiona estado de página y reset al filtrar.

  Tests

  - 2 tests nuevos: el page_size se respeta y la búsqueda abarca todas las filas (no solo la página actual).
  - Suite backend completa en verde (47 tests) y build de frontend (tsc strict) sin errores.

